### PR TITLE
Support JSON literals in INSERT.

### DIFF
--- a/driver_test.go
+++ b/driver_test.go
@@ -164,6 +164,7 @@ func TestInsertAndQuery(t *testing.T) {
 	rushHour := fixtures.Movie{"Rush Hour", 1998, fixtures.MovieInfo{}}
 	forrestGump := fixtures.Movie{"Forrest Gump", 1994, fixtures.MovieInfo{}}
 	inception := fixtures.Movie{"Inception", 2010, fixtures.MovieInfo{}}
+	dieHard := fixtures.Movie{"Die Hard", 1988, fixtures.MovieInfo{}}
 
 	v, err := db.Exec("INSERT INTO movies VALUES (?)", []fixtures.Movie{
 		prisoners, rushHour,
@@ -184,11 +185,16 @@ INSERT INTO movies VALUES
 ('{"title":"Inception", "year": 2010}')
 `)
 	require.NoError(t, err)
+	v, err = db.Exec(`
+INSERT INTO movies VALUES
+({title:"Die Hard", year:1988})
+`)
+	require.NoError(t, err)
 	rows, err = v.RowsAffected()
 	require.NoError(t, err)
 	require.Equal(t, int64(1), rows)
 
-	for _, m := range []fixtures.Movie{prisoners, rushHour, forrestGump, inception} {
+	for _, m := range []fixtures.Movie{prisoners, rushHour, forrestGump, inception, dieHard} {
 		row := db.QueryRow(`SELECT * FROM movies WHERE title = ?`, m.Title)
 		var movie fixtures.Movie
 		require.NoError(t, row.Scan(Document(&movie)))

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -96,7 +96,7 @@ func TestParseInsert(t *testing.T) {
 			query: "INSERT INTO `movies` VALUES (?)",
 			ast: &AST{Insert: &Insert{
 				Into:   "movies",
-				Values: []*ValueRow{{Value: &Value{PositionalPlaceholder: aws.Bool(true)}}},
+				Values: []*InsertTerminal{{Value: Value{PositionalPlaceholder: true}}},
 			}},
 		},
 		{
@@ -109,12 +109,12 @@ VALUES ('{"title":"hello","year":2009}'),
 			ast: &AST{
 				Insert: &Insert{
 					Into: "movies",
-					Values: []*ValueRow{
+					Values: []*InsertTerminal{
 						{
-							Value: &Value{String: aws.String(`{"title":"hello","year":2009}`)},
+							Value: Value{Scalar: Scalar{Str: aws.String(`{"title":"hello","year":2009}`)}},
 						},
 						{
-							Value: &Value{String: aws.String(`{"title":"foo","year":2938}`)},
+							Value: Value{Scalar: Scalar{Str: aws.String(`{"title":"foo","year":2938}`)}},
 						},
 					},
 				},
@@ -130,22 +130,18 @@ VALUES ({title:"hello",year:2009}),
 			ast: &AST{
 				Insert: &Insert{
 					Into: "movies",
-					Values: []*ValueRow{
+					Values: []*InsertTerminal{
 						{
-							Value: &Value{
-								Object: &Object{[]*ObjectEntry{
-									{"title", &Value{String: aws.String("hello")}},
-									{"year", &Value{Number: aws.Float64(2009)}},
-								}},
-							},
+							Object: &JSONObject{[]*JSONObjectEntry{
+								{"title", &JSONValue{Scalar: Scalar{Str: aws.String("hello")}}},
+								{"year", &JSONValue{Scalar: Scalar{Number: aws.Float64(2009)}}},
+							}},
 						},
 						{
-							Value: &Value{
-								Object: &Object{[]*ObjectEntry{
-									{"title", &Value{String: aws.String("foo")}},
-									{"year", &Value{Number: aws.Float64(2938)}},
-								}},
-							},
+							Object: &JSONObject{[]*JSONObjectEntry{
+								{"title", &JSONValue{Scalar: Scalar{Str: aws.String("foo")}}},
+								{"year", &JSONValue{Scalar: Scalar{Number: aws.Float64(2938)}}},
+							}},
 						},
 					},
 				},

--- a/parser/testdata/golden/queries.02.golden.go
+++ b/parser/testdata/golden/queries.02.golden.go
@@ -41,7 +41,9 @@ parser.row{
                   Operator: "=",
                   Operand: &parser.Operand{
                     Value: &parser.Value{
-                      String: &"The Dark Knight",
+                      Scalar: parser.Scalar{
+                        Str: &"The Dark Knight",
+                      },
                     },
                   },
                 },

--- a/parser/testdata/golden/queries.03.golden.go
+++ b/parser/testdata/golden/queries.03.golden.go
@@ -41,7 +41,9 @@ parser.row{
                   Operator: "=",
                   Operand: &parser.Operand{
                     Value: &parser.Value{
-                      String: &"The Dark Knight",
+                      Scalar: parser.Scalar{
+                        Str: &"The Dark Knight",
+                      },
                     },
                   },
                 },
@@ -62,7 +64,9 @@ parser.row{
                   Operator: ">=",
                   Operand: &parser.Operand{
                     Value: &parser.Value{
-                      Number: &2009,
+                      Scalar: parser.Scalar{
+                        Number: &2009,
+                      },
                     },
                   },
                 },

--- a/parser/testdata/golden/queries.04.golden.go
+++ b/parser/testdata/golden/queries.04.golden.go
@@ -41,7 +41,9 @@ parser.row{
                   Operator: "=",
                   Operand: &parser.Operand{
                     Value: &parser.Value{
-                      String: &"The Dark Knight",
+                      Scalar: parser.Scalar{
+                        Str: &"The Dark Knight",
+                      },
                     },
                   },
                 },
@@ -61,12 +63,16 @@ parser.row{
                 Between: &parser.Between{
                   Start: &parser.Operand{
                     Value: &parser.Value{
-                      Number: &2009,
+                      Scalar: parser.Scalar{
+                        Number: &2009,
+                      },
                     },
                   },
                   End: &parser.Operand{
                     Value: &parser.Value{
-                      Number: &2015,
+                      Scalar: parser.Scalar{
+                        Number: &2015,
+                      },
                     },
                   },
                 },

--- a/parser/testdata/golden/queries.05.golden.go
+++ b/parser/testdata/golden/queries.05.golden.go
@@ -41,7 +41,9 @@ parser.row{
                   Operator: "=",
                   Operand: &parser.Operand{
                     Value: &parser.Value{
-                      String: &"The Dark Knight",
+                      Scalar: parser.Scalar{
+                        Str: &"The Dark Knight",
+                      },
                     },
                   },
                 },
@@ -61,12 +63,16 @@ parser.row{
                 Between: &parser.Between{
                   Start: &parser.Operand{
                     Value: &parser.Value{
-                      Number: &2009,
+                      Scalar: parser.Scalar{
+                        Number: &2009,
+                      },
                     },
                   },
                   End: &parser.Operand{
                     Value: &parser.Value{
-                      Number: &2015,
+                      Scalar: parser.Scalar{
+                        Number: &2015,
+                      },
                     },
                   },
                 },
@@ -87,7 +93,9 @@ parser.row{
                   Operator: "=",
                   Operand: &parser.Operand{
                     Value: &parser.Value{
-                      String: &"Will Smith",
+                      Scalar: parser.Scalar{
+                        Str: &"Will Smith",
+                      },
                     },
                   },
                 },

--- a/parser/testdata/golden/queries.06.golden.go
+++ b/parser/testdata/golden/queries.06.golden.go
@@ -41,7 +41,9 @@ parser.row{
                   Operator: "=",
                   Operand: &parser.Operand{
                     Value: &parser.Value{
-                      String: &"The Dark Knight",
+                      Scalar: parser.Scalar{
+                        Str: &"The Dark Knight",
+                      },
                     },
                   },
                 },
@@ -67,12 +69,16 @@ parser.row{
                             Between: &parser.Between{
                               Start: &parser.Operand{
                                 Value: &parser.Value{
-                                  Number: &2009,
+                                  Scalar: parser.Scalar{
+                                    Number: &2009,
+                                  },
                                 },
                               },
                               End: &parser.Operand{
                                 Value: &parser.Value{
-                                  Number: &2015,
+                                  Scalar: parser.Scalar{
+                                    Number: &2015,
+                                  },
                                 },
                               },
                             },
@@ -97,7 +103,9 @@ parser.row{
                               Operator: "=",
                               Operand: &parser.Operand{
                                 Value: &parser.Value{
-                                  String: &"Will Smith",
+                                  Scalar: parser.Scalar{
+                                    Str: &"Will Smith",
+                                  },
                                 },
                               },
                             },

--- a/parser/testdata/golden/queries.07.golden.go
+++ b/parser/testdata/golden/queries.07.golden.go
@@ -22,6 +22,8 @@ parser.row{
                   Operator: "=",
                   Operand: &parser.Operand{
                     Value: &parser.Value{
+                      Scalar: parser.Scalar{
+                      },
                       PlaceHolder: &":title",
                     },
                   },

--- a/parser/testdata/golden/queries.08.golden.go
+++ b/parser/testdata/golden/queries.08.golden.go
@@ -22,6 +22,8 @@ parser.row{
                   Operator: "=",
                   Operand: &parser.Operand{
                     Value: &parser.Value{
+                      Scalar: parser.Scalar{
+                      },
                       PlaceHolder: &":title",
                     },
                   },

--- a/parser/testdata/golden/queries.09.golden.go
+++ b/parser/testdata/golden/queries.09.golden.go
@@ -22,6 +22,8 @@ parser.row{
                   Operator: "=",
                   Operand: &parser.Operand{
                     Value: &parser.Value{
+                      Scalar: parser.Scalar{
+                      },
                       PlaceHolder: &":title",
                     },
                   },
@@ -44,7 +46,9 @@ parser.row{
                 },
                 {
                   Value: &parser.Value{
-                    String: &"Will",
+                    Scalar: parser.Scalar{
+                      Str: &"Will",
+                    },
                   },
                 },
               },

--- a/parser/testdata/golden/queries.10.golden.go
+++ b/parser/testdata/golden/queries.10.golden.go
@@ -41,6 +41,8 @@ parser.row{
                   Operator: "=",
                   Operand: &parser.Operand{
                     Value: &parser.Value{
+                      Scalar: parser.Scalar{
+                      },
                       PlaceHolder: &":UserId",
                     },
                   },

--- a/parser/testdata/golden/queries.11.golden.go
+++ b/parser/testdata/golden/queries.11.golden.go
@@ -48,6 +48,8 @@ parser.row{
                   Operator: "=",
                   Operand: &parser.Operand{
                     Value: &parser.Value{
+                      Scalar: parser.Scalar{
+                      },
                       PlaceHolder: &":UserId",
                     },
                   },

--- a/parser/testdata/golden/queries.12.golden.go
+++ b/parser/testdata/golden/queries.12.golden.go
@@ -65,6 +65,8 @@ parser.row{
                   Operator: "=",
                   Operand: &parser.Operand{
                     Value: &parser.Value{
+                      Scalar: parser.Scalar{
+                      },
                       PlaceHolder: &":UserId",
                     },
                   },

--- a/parser/testdata/golden/queries.13.golden.go
+++ b/parser/testdata/golden/queries.13.golden.go
@@ -108,6 +108,8 @@ parser.row{
                   Operator: "=",
                   Operand: &parser.Operand{
                     Value: &parser.Value{
+                      Scalar: parser.Scalar{
+                      },
                       PlaceHolder: &":UserId",
                     },
                   },

--- a/parser/testdata/golden/queries.14.golden.go
+++ b/parser/testdata/golden/queries.14.golden.go
@@ -115,6 +115,8 @@ parser.row{
                   Operator: "=",
                   Operand: &parser.Operand{
                     Value: &parser.Value{
+                      Scalar: parser.Scalar{
+                      },
                       PlaceHolder: &":UserId",
                     },
                   },

--- a/parser/testdata/golden/queries.15.golden.go
+++ b/parser/testdata/golden/queries.15.golden.go
@@ -48,6 +48,8 @@ parser.row{
                   Operator: "=",
                   Operand: &parser.Operand{
                     Value: &parser.Value{
+                      Scalar: parser.Scalar{
+                      },
                       PlaceHolder: &":UserId",
                     },
                   },

--- a/parser/testdata/golden/queries.16.golden.go
+++ b/parser/testdata/golden/queries.16.golden.go
@@ -35,6 +35,8 @@ parser.row{
                   Operator: "=",
                   Operand: &parser.Operand{
                     Value: &parser.Value{
+                      Scalar: parser.Scalar{
+                      },
                       PlaceHolder: &":UserId",
                     },
                   },

--- a/parser/testdata/golden/queries.17.golden.go
+++ b/parser/testdata/golden/queries.17.golden.go
@@ -22,6 +22,8 @@ parser.row{
                   Operator: "=",
                   Operand: &parser.Operand{
                     Value: &parser.Value{
+                      Scalar: parser.Scalar{
+                      },
                       PlaceHolder: &":UserId",
                     },
                   },

--- a/parser/testdata/golden/queries.18.golden.go
+++ b/parser/testdata/golden/queries.18.golden.go
@@ -23,6 +23,8 @@ parser.row{
                   Operator: "=",
                   Operand: &parser.Operand{
                     Value: &parser.Value{
+                      Scalar: parser.Scalar{
+                      },
                       PlaceHolder: &":UserId",
                     },
                   },

--- a/parser/testdata/golden/queries.19.golden.go
+++ b/parser/testdata/golden/queries.19.golden.go
@@ -22,7 +22,9 @@ parser.row{
                   Operator: "=",
                   Operand: &parser.Operand{
                     Value: &parser.Value{
-                      Boolean: &parser.Boolean(true),
+                      Scalar: parser.Scalar{
+                        Boolean: &parser.Boolean(true),
+                      },
                     },
                   },
                 },

--- a/parser/testdata/golden/queries.20.golden.go
+++ b/parser/testdata/golden/queries.20.golden.go
@@ -22,6 +22,8 @@ parser.row{
                   Operator: "=",
                   Operand: &parser.Operand{
                     Value: &parser.Value{
+                      Scalar: parser.Scalar{
+                      },
                       PlaceHolder: &":UserId",
                     },
                   },

--- a/parser/testdata/golden/queries.21.golden.go
+++ b/parser/testdata/golden/queries.21.golden.go
@@ -22,6 +22,8 @@ parser.row{
                   Operator: "=",
                   Operand: &parser.Operand{
                     Value: &parser.Value{
+                      Scalar: parser.Scalar{
+                      },
                       PlaceHolder: &":UserId",
                     },
                   },

--- a/parser/testdata/golden/queries.22.golden.go
+++ b/parser/testdata/golden/queries.22.golden.go
@@ -22,7 +22,9 @@ parser.row{
                   Operator: "=",
                   Operand: &parser.Operand{
                     Value: &parser.Value{
-                      PositionalPlaceholder: &true,
+                      Scalar: parser.Scalar{
+                      },
+                      PositionalPlaceholder: true,
                     },
                   },
                 },
@@ -43,7 +45,9 @@ parser.row{
                   Operator: ">",
                   Operand: &parser.Operand{
                     Value: &parser.Value{
-                      PositionalPlaceholder: &true,
+                      Scalar: parser.Scalar{
+                      },
+                      PositionalPlaceholder: true,
                     },
                   },
                 },

--- a/querybuilder/testdata/golden/queries_invalid.golden.json
+++ b/querybuilder/testdata/golden/queries_invalid.golden.json
@@ -46,5 +46,9 @@
   {
     "Query": "SELECT * FROM gamescores WHERE UserId = :UserId AND Wins = ?",
     "Error": "cannot mix positional params (?) with named params (:param)"
+  },
+  {
+    "Query": "SELECT * FROM gamescores WHERE UserId = {id: 10}",
+    "Error": "1:39: unexpected token \"=\" (expected \"(\")"
   }
 ]

--- a/querybuilder/testdata/queries_invalid.sql
+++ b/querybuilder/testdata/queries_invalid.sql
@@ -22,3 +22,5 @@ SELECT * FROM gamescores WHERE UserId = :UserId AND GameTitle = "A" AND GameTitl
 SELECT * FROM gamescores WHERE UserId = :UserId AND attribute_exists(GameTitle)
 -- Mix ? and : placeholders
 SELECT * FROM gamescores WHERE UserId = :UserId AND Wins = ?
+-- Use JSON in query
+SELECT * FROM gamescores WHERE UserId = {id: 10}


### PR DESCRIPTION
I decided to restructure the parser to only allow JSON literals in
INSERT statements as I think it's clearer. As part of this I factored
out scalar literals into their own AST node.